### PR TITLE
Add NuGet package to Referenced 

### DIFF
--- a/Referenced/Referenced.csproj
+++ b/Referenced/Referenced.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\TransitiveReferenced\TransitiveReferenced.csproj" />
   </ItemGroup>
 

--- a/Referencing/Referencing.csproj
+++ b/Referencing/Referencing.csproj
@@ -1,11 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <ProjectReference Include="..\Referenced\Referenced.csproj" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>net472</TargetFramework>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
-  </PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Referenced\Referenced.csproj">
+			<Private>False</Private>
+		</ProjectReference>
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Add NuGet Package to Referenced project to demonstrate that all packages and ransitive project refs end up in Referencing project.

Output in Referenced Project:

![image](https://user-images.githubusercontent.com/1374013/181070289-c3e9cb3d-8098-482d-b64f-70fc3349bded.png)

Expected Output:

Should only contain `Referencing.dll`.
